### PR TITLE
Added SnS option for specific headers

### DIFF
--- a/HttpCall.cpp
+++ b/HttpCall.cpp
@@ -80,7 +80,7 @@ void HttpCall::deleteKey(int key) {
     curls[key] = nullptr;
 }
 
-HttpCallResponse HttpCall::call(int key, HttpMethod method, const std::string& url, const std::string& data, int timeOut) const {
+HttpCallResponse HttpCall::call(int key, HttpMethod method, const std::string& url, const std::string& data, int timeOut, bool isSns) const {
     CURL* curl = getCurl(key);
     if (curl == nullptr) {
         HttpCallResponse response;
@@ -88,7 +88,7 @@ HttpCallResponse HttpCall::call(int key, HttpMethod method, const std::string& u
         response.response = "Failed to initialize libcurl.";
         return response;
     }
-    if (!setOptions(curl, method, url, data, timeOut)) {
+    if (!setOptions(curl, method, url, data, timeOut, isSns)) {
         HttpCallResponse response;
         response.code = -1;
         response.response = "Failed to set options.";
@@ -118,14 +118,14 @@ CURL* HttpCall::getCurl(int key) const {
     return curls[key];
 }
 
-bool HttpCall::setOptions(CURL* curl, HttpMethod method, const string& url, const string& data, int timeOut) const {
+bool HttpCall::setOptions(CURL* curl, HttpMethod method, const string& url, const string& data, int timeOut, bool isSns) const {
     curl_easy_reset(curl);
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpCall::write_callback);
     /* activate when debugging
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_HEADER, 1L);*/
-    
+
     if (timeOut > 0) {
         curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, timeOut);
     }
@@ -142,6 +142,9 @@ bool HttpCall::setOptions(CURL* curl, HttpMethod method, const string& url, cons
         //todo: will add other content type support later
         struct curl_slist *headers = nullptr;
         headers = curl_slist_append(headers, "Content-Type: application/json");
+        if (isSns) {
+            curl_slist_append(headers, "vitamin-racl-token: vitamin-racl-token");
+        }
         curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str());
     }

--- a/HttpCall.hpp
+++ b/HttpCall.hpp
@@ -28,11 +28,11 @@ public:
     int createKey();
     void deleteKey(int key);
 
-    HttpCallResponse call(int key, HttpMethod method, const std::string& url, const std::string& data="", int timeOut=0) const;
+    HttpCallResponse call(int key, HttpMethod method, const std::string& url, const std::string& data="", int timeOut=0, bool isSns=false) const;
 
 private:
     CURL* getCurl(int key) const;
-    bool setOptions(CURL* curl, HttpMethod method, const std::string& url, const std::string& data="", int timeOut=0) const;
+    bool setOptions(CURL* curl, HttpMethod method, const std::string& url, const std::string& data="", int timeOut=0, bool isSns=false) const;
 
     static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
 };

--- a/ParseArguments.cpp
+++ b/ParseArguments.cpp
@@ -20,7 +20,8 @@ string ParseArguments::toString() const {
         "time out: " + ::to_string(_timeOut) + "\n" +
         "delimiters: " + _delimiters + "\n" +
         "is force run: " + (_isForceRun ? "true" : "false") + "\n" +
-        "num api calls: " + ::to_string(_numApiCalls);
+        "num api calls: " + ::to_string(_numApiCalls) + "\n" +
+        "is sns: " + (_isSns ? "true" : "false");
 }
 
 void ParseArguments::parseArguments(int argc, char* argv[]) {
@@ -37,6 +38,7 @@ void ParseArguments::parseArguments(int argc, char* argv[]) {
     _isForceRun = false;
     _timeOut = 0;
     _numApiCalls = 0;
+    _isSns = false;
 
     // update optional parameters and get vector of mandatory ones
     vector<string> arguments = extractOptionalArguments(argc, argv);
@@ -84,6 +86,8 @@ vector<string> ParseArguments::extractOptionalArguments(int argc, char* argv[]) 
             if (++cur < argc) {
                 _numApiCalls = atoi(argv[cur]);
             }
+        } else if (0 == arg.compare("-s") || 0 == arg.compare("--sns")) {
+            _isSns = true;
         } else {
             arguments.push_back(arg);
         }

--- a/ParseArguments.hpp
+++ b/ParseArguments.hpp
@@ -22,6 +22,7 @@ public:
     bool isForceRun() const { return _isForceRun; }
     std::string toString() const;
     int getNumApiCalls() const { return _numApiCalls; }
+    bool isSns() const { return _isSns; }
 
 private:
     void parseArguments(int argc, char* argv[]);
@@ -43,6 +44,7 @@ private:
     std::string _delimiters;
     bool _isForceRun;
     int _numApiCalls;
+    bool _isSns;
 
 };
 

--- a/easyapi.cpp
+++ b/easyapi.cpp
@@ -44,7 +44,7 @@ void processSingleApiCall(const ParseArguments& pa) {
     }
     HttpCall httpCall;
     int key = httpCall.createKey();
-    HttpCallResponse response = httpCall.call(key, pa.getMethod(), pa.getUrl(), pa.getData(), pa.getTimeOut());
+    HttpCallResponse response = httpCall.call(key, pa.getMethod(), pa.getUrl(), pa.getData(), pa.getTimeOut(), pa.isSns());
     cout << getHttpCallResponse(response, pa.getOutputFormat()) << endl;
 }
 
@@ -89,7 +89,7 @@ void apiCallWorker(const ParseArguments& pa, HttpCall& httpCall,
             bufferedPrint.println(inputVars + getTestCommand(pa.getMethod(), pathTemplate, varjsonTemplate));
         } else {
             auto start = high_resolution_clock::now();
-            HttpCallResponse response = httpCall.call(key, pa.getMethod(), pathTemplate, varjsonTemplate, pa.getTimeOut());
+            HttpCallResponse response = httpCall.call(key, pa.getMethod(), pathTemplate, varjsonTemplate, pa.getTimeOut(), pa.isSns());
             auto stop = high_resolution_clock::now();
             auto duration = duration_cast<milliseconds>(stop - start);
             elappsedTime += duration.count();
@@ -110,7 +110,7 @@ void apiCallWorker2(const ParseArguments& pa, HttpCall& httpCall, int numCalls,
             bufferedPrint.println(getTestCommand(pa.getMethod(), path, data));
         } else {
             auto start = high_resolution_clock::now();
-            HttpCallResponse response = httpCall.call(key, pa.getMethod(), path, data, pa.getTimeOut());
+            HttpCallResponse response = httpCall.call(key, pa.getMethod(), path, data, pa.getTimeOut(), pa.isSns());
             auto stop = high_resolution_clock::now();
             auto duration = duration_cast<milliseconds>(stop - start);
             elappsedTime += duration.count();
@@ -167,7 +167,7 @@ void processMultipleApiCalls(const ParseArguments& pa,
     }
     // read lines from data_file, show configuration, and getting confirmation to go forward
     string line;
-    vector<string> lines; 
+    vector<string> lines;
     while (getline(variableData, line)) {
         lines.push_back(line);
     }
@@ -344,6 +344,7 @@ int main(int argc, char* argv[]) {
         cout << "  --delimiters or -d" << "\t" << "Defile a delimiter. Default is space and comma (\" ,\")." << endl;
         cout << "  --force-run or -fr" << "\t" << "Forced run. If this option is set, not asking to check input parameters. So, please be very cautious when using this option." << endl;
         cout << "  --num-api-calls or -nc" << "\t" << "The number of api calls. When data-file is not set and this is greater than zero, api calls will be repeated by this parameter." << endl;
+        cout << "  --sns or -s" << "\t" << "For SnS API calls. All SnS APIs require sepcific headers." << endl;
         return 0;
     }
 


### PR DESCRIPTION
Manual test

➜  ebapi git:(master) ✗ ./easyapi post 'http://10.213.249.88/api/subs/migrateExpiryDate?paymentInfoId=151&checkFlag=true' '{}' -s`


{
    "content": null,
    "errorMsg": null,
    "notification": "NONE",
    "oldSequenceId": null,
    "paymentInfoDTO": null,
    "success": true,
    "updateAction": false,
    "warnMsg": null
}